### PR TITLE
Updates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,7 @@ Dockerfile      text eol=lf
 *.scss          text eol=lf
 *.js            text eol=lf
 *.jsx           text eol=lf
+*.mjs           text eol=lf
 *.ts            text eol=lf
 *.tsx           text eol=lf
 *.map           text eol=lf

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,18 +19,19 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const tag = "latest";
-          const deployment = await github.repos.createDeployment({
+          const deployment = await github.rest.repos.createDeployment({
             environment: tag,
             ref: "${{ github.sha }}",
             owner: context.repo.owner,
             repo: context.repo.repo,
-            required_contexts: [] 
+            required_contexts: []
           });
           core.setOutput("id", deployment.data.id);
           core.setOutput("tag", 'latest');
 
     - name: Parameters
       run: |
+        echo SHA ${{ github.sha }}
         echo Branch ${{ github.ref }}
         echo Deployment ${{ steps.deployment.outputs.id }}
         echo Tag ${{ steps.deployment.outputs.tag }}
@@ -48,7 +49,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          github.repos.createDeploymentStatus({
+          github.rest.repos.createDeploymentStatus({
             owner: context.repo.owner,
             repo: context.repo.repo,
             deployment_id: '${{ steps.deployment.outputs.id }}',
@@ -61,7 +62,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          github.repos.createDeploymentStatus({
+          github.rest.repos.createDeploymentStatus({
             owner: context.repo.owner,
             repo: context.repo.repo,
             deployment_id: '${{ steps.deployment.outputs.id }}',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "devDependencies": {
     "mocha": "9.1.2",
-    "node-fetch": "2.6.1"
+    "node-fetch": "3.0.0"
   },
   "scripts": {
     "test": "mocha test/mocha/*.test.js --timeout 5000"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "node-fetch": "3.0.0"
   },
   "scripts": {
-    "test": "mocha test/mocha/*.test.js --timeout 5000"
+    "test": "mocha test/mocha/*.test.mjs --timeout 5000"
   }
 }

--- a/test/mocha/index.test.mjs
+++ b/test/mocha/index.test.mjs
@@ -1,8 +1,6 @@
 /* eslint-env node, mocha */
-/* eslint-disable prefer-arrow-callback */
-"use strict";
-const {strictEqual} = require("assert");
-const fetch = require("node-fetch");
+import {strictEqual} from "assert";
+import fetch from "node-fetch";
 
 describe("index", function () {
 	it("Root", async function () {

--- a/test/mocha/logs.test.mjs
+++ b/test/mocha/logs.test.mjs
@@ -1,10 +1,7 @@
 /* eslint-env node, mocha */
-/* eslint-disable prefer-arrow-callback */
-"use strict";
-const {strictEqual, deepStrictEqual} = require("assert");
-const {readdir, readFile} = require("fs/promises");
-const fetch = require("node-fetch");
-
+import {strictEqual, deepStrictEqual} from "assert";
+import {readdir, readFile} from "fs/promises";
+import fetch from"node-fetch";
 
 describe("Logs", function () {
 	it("Custom filepaths", async function () {

--- a/test/mocha/rewrite.test.mjs
+++ b/test/mocha/rewrite.test.mjs
@@ -1,8 +1,6 @@
 /* eslint-env node, mocha */
-/* eslint-disable prefer-arrow-callback */
-"use strict";
-const {strictEqual} = require("assert");
-const fetch = require("node-fetch");
+import {strictEqual} from "assert";
+import fetch from "node-fetch";
 
 describe("rewrite", function () {
 	it("http://rewrite.local/add", async function () {

--- a/test/mocha/status.test.mjs
+++ b/test/mocha/status.test.mjs
@@ -1,8 +1,6 @@
 /* eslint-env node, mocha */
-/* eslint-disable prefer-arrow-callback */
-"use strict";
-const {strictEqual} = require("assert");
-const fetch = require("node-fetch");
+import {strictEqual} from "assert";
+import fetch from "node-fetch";
 
 describe("Status", function () {
 	it("410 by default", async function () {

--- a/test/mocha/try_files.test.mjs
+++ b/test/mocha/try_files.test.mjs
@@ -1,8 +1,6 @@
 /* eslint-env node, mocha */
-/* eslint-disable prefer-arrow-callback */
-"use strict";
-const {strictEqual} = require("assert");
-const fetch = require("node-fetch");
+import {strictEqual} from "assert";
+import fetch from "node-fetch";
 
 describe("Redirection", function () {
 	it("/redirection", async function () {


### PR DESCRIPTION
1. Fixes the **Publish** action (v5 uses `.rest` now).
2. Upgrades the `node-fetch` devDependency.
3. Converts tests to MJS (because of node-fetch's breaking change).